### PR TITLE
Change "Handlebars" to "handlebars" in task file to fix bug that causes Handlebars object to be undefined

### DIFF
--- a/tasks/handlebars_requirejs.js
+++ b/tasks/handlebars_requirejs.js
@@ -61,7 +61,7 @@ module.exports = function(grunt) {
         filename = processName(file);
 
         output  = ""
-        output += "define(['handlebars'], function(Handlebars){\n"
+        output += "define(['handlebars'], function(handlebars){\n"
         output += "var template = " + compiled + "\n"
         if (options.makePartials) {
           partialName = filename.replace(/\//g,'.')


### PR DESCRIPTION
This is necessary because passing in a capital "H" in the compiled files will cause an error such that the Handlebars object in the body of the code is undefined.

The following is the error I was getting in the console.
![image](https://f.cloud.github.com/assets/4447823/1356786/d5140baa-3780-11e3-8cf1-7c8e4f682cf0.png)

I made the change from:
![image](https://f.cloud.github.com/assets/4447823/1356789/e902fe78-3780-11e3-9f61-7ab82a0fa6fb.png)

to:
![image](https://f.cloud.github.com/assets/4447823/1356790/ee516d74-3780-11e3-87e8-3091c85e34b7.png)

and no longer received an error and my page loaded properly.
![image](https://f.cloud.github.com/assets/4447823/1356809/44cc7310-3781-11e3-9bea-a71a3be17f30.png)
